### PR TITLE
Add ability to set HTTP Client Request checkStatus Function

### DIFF
--- a/Network/Wreq.hs
+++ b/Network/Wreq.hs
@@ -71,7 +71,9 @@ module Network.Wreq
     , Lens.headers
     , Lens.params
     , Lens.cookie
-    , Lens.cookies
+    , Lens.cookies 
+    , Lens.checkStatus
+    
     -- ** Authentication
     -- $auth
     , Auth

--- a/Network/Wreq/Internal/Types.hs
+++ b/Network/Wreq/Internal/Types.hs
@@ -42,7 +42,7 @@ module Network.Wreq.Internal.Types
     ) where
 
 import Control.Concurrent.MVar (MVar)
-import Control.Exception (Exception)
+import Control.Exception (Exception, SomeException)
 import Data.Monoid ((<>), mconcat)
 import Data.Text (Text)
 import Data.Time.Clock (UTCTime)
@@ -50,7 +50,7 @@ import Data.Typeable (Typeable)
 import Network.HTTP.Client (CookieJar, Manager, ManagerSettings, Request,
                             RequestBody, destroyCookieJar)
 import Network.HTTP.Client.Internal (Response, Proxy)
-import Network.HTTP.Types (Header)
+import Network.HTTP.Types (Header, Status, ResponseHeaders)
 import Prelude hiding (head)
 import qualified Data.ByteString.Char8 as S
 import qualified Data.ByteString.Lazy as L
@@ -148,6 +148,13 @@ data Options = Options {
   -- etc.), this field will be used only for the /first/ HTTP request
   -- to be issued during a 'Network.Wreq.Session.Session'. Any changes
   -- changes made for subsequent requests will be ignored.
+  , checkStatus :: 
+    Maybe (Status -> ResponseHeaders -> CookieJar -> Maybe SomeException)
+  -- ^ Function that checks the status code and potentially returns an exception.
+  --
+  -- This defaults to 'Nothing', which will just use the default of
+  -- 'Network.HTTP.Client.Request' which throws a 'StatusException' if the status
+  -- is not 2XX. 
   } deriving (Typeable)
 
 -- | Supported authentication types.

--- a/Network/Wreq/Lens.hs
+++ b/Network/Wreq/Lens.hs
@@ -45,6 +45,7 @@ module Network.Wreq.Lens
     , params
     , cookie
     , cookies
+    , checkStatus
 
     -- ** Proxy setup
     , Proxy
@@ -99,6 +100,7 @@ module Network.Wreq.Lens
     ) where
 
 import Control.Applicative ((<*))
+import Control.Exception (SomeException)
 import Control.Lens (Fold, Lens, Lens', Traversal', folding)
 import Data.Attoparsec (Parser, endOfInput, parseOnly)
 import Data.ByteString (ByteString)
@@ -210,6 +212,10 @@ params = TH.params
 -- @
 redirects :: Lens' Options Int
 redirects = TH.redirects
+
+-- | A lens to get the optional status check function
+checkStatus :: Lens' Options (Maybe (Status -> ResponseHeaders -> CookieJar -> Maybe SomeException))
+checkStatus = TH.checkStatus
 
 -- | A traversal onto the cookie with the given name, if one exists.
 cookie :: ByteString -> Traversal' Options Cookie

--- a/Network/Wreq/Lens/TH.hs
+++ b/Network/Wreq/Lens/TH.hs
@@ -15,6 +15,7 @@ module Network.Wreq.Lens.TH
     , redirects
     , cookie
     , cookies
+    , checkStatus
 
     , HTTP.Cookie
     , cookieName


### PR DESCRIPTION
Thanks for the module! It's always nice to have places around hackage that have been all prettied up with lenses! :)

I hit a bit in a program that I was writing where I needed to get to the body of a response that was not a 2XX response. I couldn't find a way in wreq to set the checkStatus function of the underlaying http client so I added it into the options data type. 

The test case that I wrote passes and I have also tested the updated version in the application that I was running and it works just swimmingly, but I'm happy to take comments and make changes as you need or want me to. 
