### PR TITLE
Restrict upper bound for lens to < 4.4

### DIFF
--- a/wreq.cabal
+++ b/wreq.cabal
@@ -1,5 +1,5 @@
 name:                wreq
-version:             0.2.1.0
+version:             0.2.1.1
 synopsis:            An easy-to-use HTTP client library.
 description:
   .
@@ -103,7 +103,7 @@ library
     http-client >= 0.3.1.1,
     http-client-tls >= 0.2,
     http-types >= 0.8,
-    lens >= 4.1,
+    lens >= 4.1 && < 4.4,
     mime-types,
     old-locale,
     template-haskell,
@@ -164,7 +164,7 @@ test-suite tests
     hashable,
     http-client,
     http-types,
-    lens >= 4.1,
+    lens >= 4.1 && < 4.4,
     snap-core,
     snap-server >= 0.9.4.4,
     temporary,


### PR DESCRIPTION
Hi,

due to latest changes in lens 4.4 wreq does unfortunately no longer build with that version.

I adjusted the upper bound to lens >= 4.1 && < 4.4 and bumped the version in the cabal file from 0.2.1.0 to 0.2.1.1.

The error is that lens 4.4 does no longer define `defaultRules` in Control.Lens.TH.  See also the release notes here: http://www.reddit.com/r/haskell/comments/2e9918/lens_44_release_notes/

Best,
Markus
