### PR TITLE
Added `statusMessage` as an exported function

### DIFF
--- a/Network/Wreq.hs
+++ b/Network/Wreq.hs
@@ -120,6 +120,7 @@ module Network.Wreq
     , Lens.responseStatus
     , Lens.Status
     , Lens.statusCode
+    , Lens.statusMessage
     -- ** Link headers
     , Lens.Link
     , Lens.linkURL


### PR DESCRIPTION
I don't know if this is an omission or if it is on purpose but I felt this was missing as I was going to the tutorial and playing with the API.
