### PR TITLE
Add `withSessionWithMgr` function.

### DIFF
--- a/Network/Wreq/Session.hs
+++ b/Network/Wreq/Session.hs
@@ -5,6 +5,7 @@ module Network.Wreq.Session
       Session
     , withSession
     , withSessionWith
+    , withSessionWithMgr
     -- * HTTP verbs
     , get
     , post
@@ -46,6 +47,13 @@ withSessionWith settings act = do
                 , seshManager = mgr
                 , seshRun = runWith
                 }
+withSessionWithMgr :: HTTP.Manager -> (Session -> IO a) -> IO a
+withSessionWithMgr mgr act = do
+  mv <- newMVar $ HTTP.createCookieJar []
+  act Session { seshCookies = mv
+              , seshManager = mgr
+              , seshRun = runWith
+              }
 
 get :: Session -> String -> IO (Response L.ByteString)
 get = getWith defaults


### PR DESCRIPTION
I think is useful be able to share `Network.HTTP.Client.Manager` among sessions. My original problem was http://stackoverflow.com/questions/27268014/withsession-from-network-wreq-and-memory-usage (Thank you!)
