### PR TITLE
Add two more ways of authentication for the OAuth 1.0a workflow

### DIFF
--- a/Network/Wreq.hs
+++ b/Network/Wreq.hs
@@ -88,6 +88,8 @@ module Network.Wreq
     , Lens.auth
     , basicAuth
     , oauth1Auth
+    , oauth1Temp
+    , oauth1ReqAccessToken
     , oauth2Bearer
     , oauth2Token
     , awsAuth
@@ -463,13 +465,30 @@ basicAuth = BasicAuth
 
 -- | OAuth1 authentication. This consists of a consumer token,
 -- a consumer secret, a token and a token secret
-oauth1Auth :: S.ByteString          -- ^ Consumer token
-       -> S.ByteString          -- ^ Consumer secret
-       -> S.ByteString          -- ^ OAuth token
-       -> S.ByteString          -- ^ OAuth token secret
-       -> Auth
+oauth1Auth :: S.ByteString      -- ^ Consumer token
+           -> S.ByteString      -- ^ Consumer secret
+           -> S.ByteString      -- ^ OAuth token
+           -> S.ByteString      -- ^ OAuth token secret
+           -> Auth
 oauth1Auth = OAuth1
 
+-- | OAuth1 temporary token authentication. This consists of
+-- a consumer token, a consumer secret and a callback URI
+oauth1Temp :: S.ByteString      -- ^ Consumer token
+           -> S.ByteString      -- ^ Consumer secret
+           -> S.ByteString      -- ^ Callback URI
+           -> Auth
+oauth1Temp = OAuth1Temp
+
+-- | OAuth1 access token authentication. Used to make requests
+-- to exchange temporary tokens for access tokens
+oauth1ReqAccessToken :: S.ByteString  -- ^ Consumer token
+                     -> S.ByteString  -- ^ Consumer secret
+                     -> S.ByteString  -- ^ Temporary token
+                     -> S.ByteString  -- ^ Temporary secret
+                     -> S.ByteString  -- ^ OAuth Verifier
+                     -> Auth
+oauth1ReqAccessToken = OAuth1ReqAccessToken
 
 -- | An OAuth2 bearer token. This is treated by many services as the
 -- equivalent of a username and password.

--- a/Network/Wreq/Internal/OAuth1.hs
+++ b/Network/Wreq/Internal/OAuth1.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 module Network.Wreq.Internal.OAuth1
   (
    signRequest
@@ -5,13 +7,32 @@ module Network.Wreq.Internal.OAuth1
 
 import Network.HTTP.Client (Request(..))
 import Network.Wreq.Internal.Types (Auth(..))
-import Web.Authenticate.OAuth ( signOAuth, newOAuth, oauthConsumerKey
-                              , oauthConsumerSecret, newCredential)
+import Web.Authenticate.OAuth ( signOAuth
+                              , newOAuth
+                              , oauthConsumerKey
+                              , oauthConsumerSecret
+                              , newCredential
+                              , oauthCallback
+                              , emptyCredential
+                              , injectVerifier
+                              , insert)
+
 
 signRequest :: Auth -> Request -> IO Request
 signRequest (OAuth1 consumerToken consumerSecret token tokenSecret) requestToSign = signOAuth app creds requestToSign
   where
-    app = newOAuth { oauthConsumerKey = consumerToken, oauthConsumerSecret = consumerSecret }
+    app   = newOAuth { oauthConsumerKey = consumerToken, oauthConsumerSecret = consumerSecret }
     creds = newCredential token tokenSecret
-
+signRequest (OAuth1Temp consumerToken consumerSecret callbackUri) requestToSign = signOAuth app creds requestToSign
+  where
+    app   = newOAuth { oauthConsumerKey = consumerToken
+                     , oauthConsumerSecret = consumerSecret
+                     , oauthCallback = Just callbackUri }
+    creds = insert "oauth_callback" callbackUri emptyCredential
+signRequest (OAuth1ReqAccessToken consumerToken consumerSecret requestToken requestTokenSecret oauthVerifier) requestToSign
+  = signOAuth app creds requestToSign
+    where
+      app   = newOAuth { oauthConsumerKey = consumerToken
+                       , oauthConsumerSecret = consumerSecret }
+      creds = injectVerifier oauthVerifier $ newCredential requestToken requestTokenSecret
 signRequest _ requestToSign = return requestToSign

--- a/Network/Wreq/Internal/Types.hs
+++ b/Network/Wreq/Internal/Types.hs
@@ -178,6 +178,19 @@ data Auth = BasicAuth S.ByteString S.ByteString
             -- ^ Amazon Web Services request signing
             -- AWSAuthVersion key secret
           | OAuth1 S.ByteString S.ByteString S.ByteString S.ByteString
+            -- ^ OAuth1 authentication to access protected requests
+            -- OAuth1 consumerToken consumerSecret token tokenSecret
+            -- consumerToken and consumerSecret are specific to your application
+            -- token and tokenSecret are specific to the (protected) resource-owner
+          | OAuth1Temp S.ByteString S.ByteString S.ByteString
+            -- ^ OAuth1Temp authentication used to request temporary credentials
+            -- to request an access token pair
+            -- OAuth1Temp consumerToken consumerSecret callbackUri
+          | OAuth1ReqAccessToken S.ByteString S.ByteString S.ByteString S.ByteString S.ByteString
+            -- ^ OAuth1RequestAccessToken used to request an access token
+            -- using a pair of (already procured) temporary credentials
+            -- OAuth1RequestAccessToken consumerToken consumerSecret tempToken tempSecret oauthVerifier
+
           deriving (Eq, Show, Typeable)
 
 data AWSAuthVersion = AWSv4


### PR DESCRIPTION
This pull request is a superset of #45. I'm not sure if the changes here make sense to add to Wreq. This adds three more authentication options:
1. The first one to make requests once the user has API keys (consumer token, consumer secret) and access tokens for a resource-owner.
2. The second one to ask a service provider to generate temporary tokens so the client can request permission from the resource-owner using the redirection workflow common in OAuth 1.0a.
3. A third one to exchange temporary tokens and an oauth_verifier token for access tokens in order to finish authentication.

This effectively makes Wreq capable of conducting the whole three-legged authentication required by a service provider such as Twitter.

Only OAuth 1.0a is supported, mainly because I'm not sure how to support OAuth 1.0 without adding three more constructors to the Auth type.
