### PR TITLE
Configure Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,31 @@
+env:
+ - CABALVER=1.16 GHCVER=7.4.2
+ - CABALVER=1.16 GHCVER=7.6.3
+ - CABALVER=1.20 GHCVER=7.8.4
+ - CABALVER=1.22 GHCVER=7.10.1
+ - CABALVER=head GHCVER=head
+
+matrix:
+  allow_failures:
+   - env: CABALVER=head GHCVER=head
+
+before_install:
+ - sudo add-apt-repository -y ppa:hvr/ghc
+ - sudo apt-get update -qq
+
+install:
+ - sudo apt-get install -qq cabal-install-$CABALVER ghc-$GHCVER
+ - export PATH="/opt/cabal/$CABALVER/bin:/opt/ghc/$GHCVER/bin:$PATH"
+
+before_script:
+ - cabal --version
+ - cabal update
+ - ghc --version
+ - ghc-pkg list
+
+script:
+ - cabal install --enable-documentation
+ - cabal sdist
+
+after_script:
+ - ghc-pkg list

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# wreq: a Haskell web client library
+# wreq: a Haskell web client library [![Build Status](https://travis-ci.org/bos/wreq.svg)](https://travis-ci.org/bos/wreq)
 
 `wreq` is a library that makes HTTP client programming in Haskell
 easy.


### PR DESCRIPTION
What do you think about enabling travis ci for `wreq`?

That makes it much easier to check if the fix for issues like #43 breaks anything.

I added a `.travis.yml` file and also added the build status to the readme.  You would just have to enable your repository on your travis account.

Here is a build with the failure on ghc-7.10 due to `time`: https://travis-ci.org/markus1189/wreq/builds/46446443

Best,
Markus