### PR TITLE
Adding support for custom http verbs with payloads

### DIFF
--- a/Network/Wreq/Internal.hs
+++ b/Network/Wreq/Internal.hs
@@ -13,6 +13,7 @@ module Network.Wreq.Internal
     , preparePost
     , runRead
     , prepareHead
+    , prepareMethodPayload
     , runIgnore
     , prepareOptions
     , preparePut
@@ -158,6 +159,10 @@ preparePost opts url payload = Req (manager opts) <$>
 prepareMethod :: HTTP.Method -> Options -> String -> IO Req
 prepareMethod method opts url = Req (manager opts) <$>
   prepare (return . (Lens.method .~ method)) opts url
+
+prepareMethodPayload :: Putable a => HTTP.Method -> Options -> String -> a -> IO Req
+prepareMethodPayload method opts url payload = Req (manager opts) <$>
+  prepare (putPayload payload . (Lens.method .~ method)) opts url
 
 prepareHead :: Options -> String -> IO Req
 prepareHead = prepareMethod HTTP.methodHead

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,12 @@
 -*- markdown -*-
 
+xxx-xxx 0.4.1.0
+
+* Introducing prepareMethodPayload, customMethodPayload,
+  customMethodPayloadWith, customMethodPayloadMaybeWith in order for
+  custom HTTP verbs to be able to take a payload. Re-using Putable
+  payload class for now.
+
 xxx-xxx 0.4.0.0
 
 * Compatible with GHC 7.10.

--- a/wreq.cabal
+++ b/wreq.cabal
@@ -1,5 +1,5 @@
 name:                wreq
-version:             0.4.0.0
+version:             0.4.1.0
 synopsis:            An easy-to-use HTTP client library.
 description:
   .


### PR DESCRIPTION
I've added support for Putable payloads for custom HTTP verb requests. Using Putable for body rather than creating a new class, as this seems to require the fewest changes for now. Further consideration could be made about if this is the right way to include a generic body payload, however.

Additional functions include:

* customMethodPayload
* customMethodPayloadWith
* customMethodPayloadMaybeWith

Documentation and tests created for new functions.

`customMethodPayloadMaybeWith` included to allow for data-driven decision to include payload.
