### PR TITLE
Allow request body on delete requests

### DIFF
--- a/Network/Wreq.hs
+++ b/Network/Wreq.hs
@@ -309,7 +309,7 @@ optionsWith opts url = runIgnore =<< prepareOptions opts url
 -- >>> r <- delete "http://httpbin.org/delete"
 -- >>> r ^. responseStatus . statusCode
 -- 200
-delete :: String -> IO (Response L.ByteString)
+delete :: Deletable a => String -> Maybe a -> IO (Response L.ByteString)
 delete = deleteWith defaults
 
 -- | Issue a DELETE request, using the supplied 'Options'.
@@ -322,11 +322,12 @@ delete = deleteWith defaults
 -- @
 --
 -- >>> let opts = defaults & redirects .~ 0
--- >>> r <- deleteWith opts "http://httpbin.org/delete"
+-- >>> r <- deleteWith opts "http://httpbin.org/delete" Nothing
 -- >>> r ^. responseStatus . statusCode
 -- 200
-deleteWith :: Options -> String -> IO (Response L.ByteString)
-deleteWith opts url = runRead =<< prepareDelete opts url
+deleteWith :: Deletable a => Options -> String -> Maybe a -> IO (Response L.ByteString)
+deleteWith opts url Nothing = runRead =<< prepareDelete opts url
+deleteWith opts url (Just payload) = runRead =<< prepareDeleteWithBody opts url payload
 
 -- | Issue a custom-method request
 --

--- a/Network/Wreq/Internal.hs
+++ b/Network/Wreq/Internal.hs
@@ -17,6 +17,7 @@ module Network.Wreq.Internal
     , prepareOptions
     , preparePut
     , prepareDelete
+    , prepareDeleteWithBody
     , prepareMethod
     ) where
 
@@ -31,7 +32,7 @@ import Network.HTTP.Client.Internal (Proxy(..), Request, Response(..), addProxy)
 import Network.HTTP.Client.TLS (tlsManagerSettings)
 import Network.Wreq.Internal.Lens (setHeader)
 import Network.Wreq.Internal.Types (Mgr, Req(..), Run)
-import Network.Wreq.Types (Auth(..), Options(..), Postable(..), Putable(..))
+import Network.Wreq.Types (Auth(..), Options(..), Postable(..), Deletable(..), Putable(..))
 import Prelude hiding (head)
 import qualified Data.ByteString as S
 import qualified Data.ByteString.Char8 as Char8
@@ -174,3 +175,7 @@ preparePut opts url payload = Req (manager opts) <$>
 
 prepareDelete :: Options -> String -> IO Req
 prepareDelete = prepareMethod HTTP.methodDelete
+
+prepareDeleteWithBody :: Deletable a => Options -> String -> a -> IO Req
+prepareDeleteWithBody opts url payload = Req (manager opts) <$>
+  prepare (deletePayload payload . (Lens.method .~ HTTP.methodDelete)) opts url

--- a/Network/Wreq/Internal/Types.hs
+++ b/Network/Wreq/Internal/Types.hs
@@ -23,6 +23,7 @@ module Network.Wreq.Internal.Types
     -- * Request payloads
     , Payload(..)
     , Postable(..)
+    , Deletable(..)
     , Putable(..)
     -- ** URL-encoded forms
     , FormParam(..)
@@ -209,6 +210,12 @@ class Postable a where
     postPayload :: a -> Request -> IO Request
     -- ^ Represent a value in the request body (and perhaps the
     -- headers) of a POST request.
+    
+-- | A type that can be converted into a DELETE request payload.
+class Deletable a where
+    deletePayload :: a -> Request -> IO Request
+    -- ^ Represent a value in the request body (and perhaps the
+    -- headers) of a DELETE request.
 
 -- | A type that can be converted into a PUT request payload.
 class Putable a where

--- a/Network/Wreq/Session.hs
+++ b/Network/Wreq/Session.hs
@@ -73,7 +73,7 @@ import Data.IORef (newIORef, readIORef, writeIORef)
 import Network.Wreq (Options, Response)
 import Network.Wreq.Internal
 import Network.Wreq.Internal.Types (Body(..), Req(..), Session(..))
-import Network.Wreq.Types (Postable, Putable, Run)
+import Network.Wreq.Types (Postable, Deletable, Putable, Run)
 import Prelude hiding (head)
 import qualified Data.ByteString.Lazy as L
 import qualified Network.HTTP.Client as HTTP
@@ -136,7 +136,7 @@ put :: Putable a => Session -> String -> a -> IO (Response L.ByteString)
 put = putWith defaults
 
 -- | 'Session'-specific version of 'Network.Wreq.delete'.
-delete :: Session -> String -> IO (Response L.ByteString)
+delete :: Deletable a => Session -> String -> Maybe a -> IO (Response L.ByteString)
 delete = deleteWith defaults
 
 -- | 'Session'-specific version of 'Network.Wreq.getWith'.
@@ -163,8 +163,9 @@ putWith :: Putable a => Options -> Session -> String -> a
 putWith opts sesh url payload = run string sesh =<< preparePut opts url payload
 
 -- | 'Session'-specific version of 'Network.Wreq.deleteWith'.
-deleteWith :: Options -> Session -> String -> IO (Response L.ByteString)
-deleteWith opts sesh url = run string sesh =<< prepareDelete opts url
+deleteWith :: Deletable a => Options -> Session -> String -> Maybe a -> IO (Response L.ByteString)
+deleteWith opts sesh url Nothing = run string sesh =<< prepareDelete opts url
+deleteWith opts sesh url (Just payload) = run string sesh =<< prepareDeleteWithBody opts url payload
 
 runWith :: Session -> Run Body -> Run Body
 runWith Session{..} act (Req _ req) = do

--- a/Network/Wreq/Types.hs
+++ b/Network/Wreq/Types.hs
@@ -22,6 +22,7 @@ module Network.Wreq.Types
     -- * Request payloads
     , Payload(..)
     , Postable(..)
+    , Deletable(..)
     , Putable(..)
     -- ** URL-encoded forms
     , FormParam(..)
@@ -84,6 +85,17 @@ instance Postable L.ByteString where
 instance Postable Value where
     postPayload = putPayload
 
+instance Deletable Payload where
+    deletePayload = putPayload
+
+instance Deletable S.ByteString where
+    deletePayload = putPayload
+
+instance Deletable L.ByteString where
+    deletePayload = putPayload
+
+instance Deletable Value where
+    deletePayload = putPayload
 
 instance Putable Payload where
     putPayload pl =

--- a/tests/UnitTests.hs
+++ b/tests/UnitTests.hs
@@ -25,7 +25,7 @@ import Network.Wreq hiding
   (get, post, head_, put, options, delete,
    getWith, postWith, headWith, putWith, optionsWith, deleteWith)
 import Network.Wreq.Lens
-import Network.Wreq.Types (Postable, Putable)
+import Network.Wreq.Types (Postable, Deletable, Putable)
 import Snap.Http.Server.Config
 import System.IO (hClose, hPutStr)
 import System.IO.Temp (withSystemTempFile)
@@ -50,8 +50,8 @@ data Verb = Verb {
   , putWith :: Putable a => Options -> String -> a -> IO (Response L.ByteString)
   , options :: String -> IO (Response ())
   , optionsWith :: Options -> String -> IO (Response ())
-  , delete :: String -> IO (Response L.ByteString)
-  , deleteWith :: Options -> String -> IO (Response L.ByteString)
+  , delete :: Deletable a => String -> Maybe a -> IO (Response L.ByteString)
+  , deleteWith :: Deletable a => Options -> String -> Maybe a -> IO (Response L.ByteString)
   }
 
 basic :: Verb
@@ -149,7 +149,7 @@ byteStringPut Verb{..} site = do
     (r ^. responseBody ^? key "headers" . key "Content-Type")
 
 basicDelete Verb{..} site = do
-  r <- delete (site "/delete")
+  r <- delete (site "/delete") (Nothing :: Maybe ByteString)
   assertEqual "DELETE succeeds" status200 (r ^. responseStatus)
 
 throwsStatusCode Verb{..} site =


### PR DESCRIPTION
Many REST APIs include DELETE requests that require a request body. eg. IronMQ.