### PR TITLE
Add getFullUri

### DIFF
--- a/Network/Wreq.hs
+++ b/Network/Wreq.hs
@@ -159,6 +159,7 @@ import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import Data.Text.Encoding (encodeUtf8)
 import Network.HTTP.Client.Internal (Proxy(..), Response)
+import Network.URI (URI)
 import Network.Wreq.Internal
 import Network.Wreq.Types (Options)
 import Network.Wreq.Types hiding (Options(..))
@@ -358,6 +359,11 @@ customMethodWith :: String -> Options -> String -> IO (Response L.ByteString)
 customMethodWith method opts url = runRead =<< prepareMethod methodBS opts url
   where
     methodBS = BC8.pack method
+
+-- | Get full 'URI' of a get-request, including protocol, query-parameters etc.
+-- Convenient for debugging.
+getFullUri :: Options -> String -> IO URI
+getFullUri opts url = return . HTTP.getUri =<< prepare return opts url
 
 foldGet :: (a -> S.ByteString -> IO a) -> a -> String -> IO a
 foldGet f z url = foldGetWith defaults f z url

--- a/Network/Wreq/Internal.hs
+++ b/Network/Wreq/Internal.hs
@@ -18,6 +18,7 @@ module Network.Wreq.Internal
     , preparePut
     , prepareDelete
     , prepareMethod
+    , prepare
     ) where
 
 import Control.Applicative ((<$>))

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,35 @@
+# For more information, see: https://github.com/commercialhaskell/stack/wiki/stack.yaml
+
+# Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
+resolver: lts-3.5
+
+# Local packages, usually specified by relative directory name
+packages:
+- '.'
+- examples/
+
+# Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
+extra-deps: []
+
+# Override default flag values for local packages and extra-deps
+flags:
+  wreq:
+    aws: false
+    doctest: true
+    httpbin: false
+    developer: false
+
+# Control whether we use the GHC we find on the path
+# system-ghc: true
+
+# Require a specific version of stack, using version ranges
+# require-stack-version: -any # Default
+# require-stack-version: >= 0.1.4.0
+
+# Override the architecture used by stack, especially useful on Windows
+# arch: i386
+# arch: x86_64
+
+# Extra directories used by stack for building
+# extra-include-dirs: [/path/to/dir]
+# extra-lib-dirs: [/path/to/dir]

--- a/wreq.cabal
+++ b/wreq.cabal
@@ -112,6 +112,7 @@ library
     lens >= 4.5,
     lens-aeson,
     mime-types,
+    network-uri,
     old-locale,
     template-haskell,
     text,


### PR DESCRIPTION
This might not look "perfect" in terms of API, so this PR is rather a starting point for a question in advice on how to do this best.

I need to debug, which URL am I querying, and currently there seems to be no way to just print URI with parameters that will be requested.

I have to admit, I couldn't get down to the very http-client source which does the request itself, so I can't say for sure if this `show (getRequestUri req) == actual requested uri`, still, this function is useful enough to work for me, so I think it might be fine as is already.

Thanks.