### PR TITLE
Remove Content-Type validation from asJSON function

### DIFF
--- a/Network/Wreq.hs
+++ b/Network/Wreq.hs
@@ -427,14 +427,9 @@ asJSON :: (MonadThrow m, FromJSON a) =>
 {-# SPECIALIZE asJSON :: (FromJSON a) =>
                          Response L.ByteString -> IO (Response a) #-}
 {-# SPECIALIZE asJSON :: Response L.ByteString -> IO (Response Aeson.Value) #-}
-asJSON resp = do
-  let contentType = fst . S.break (==59) . fromMaybe "unknown" .
-                    lookup "Content-Type" . HTTP.responseHeaders $ resp
-  unless ("application/json" `S.isPrefixOf` contentType) $
-    throwM . JSONError $ "content type of response is " ++ show contentType
-  case Aeson.eitherDecode' (HTTP.responseBody resp) of
-    Left err  -> throwM (JSONError err)
-    Right val -> return (fmap (const val) resp)
+asJSON resp = case Aeson.eitherDecode' (HTTP.responseBody resp) of
+  Left  err -> throwM (JSONError err)
+  Right val -> return (fmap (const val) resp)
 
 
 -- | Convert the body of an HTTP response from JSON to a 'Value'.


### PR DESCRIPTION
Originally, the `asJSON` function validates if the response has a content type header that starts with `application/json` before attempting to decode the response body. However, not every JSON payload has an associated content type that starts with `application/json`, notably `application/sparql-results+json` and other SPARQL MIME types.

This change removes the content type validation entirely from `asJSON`. Thus, it'll only fail if Aeson fails to parse it adequately.