### PR TITLE
Remove “TLS certificate verification” from TODO

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,8 +2,6 @@
 
 * More advanced tutorial-style documentation
 
-* TLS server certificate verification
-
 * An example that spiders a Haddock package's docs to validate its
   internal and external links
 


### PR DESCRIPTION
Unless I’m mistaken, this functionality has already been implemented (see the discussion in #82). Listing it here makes it sound as if Wreq doesn’t actually check servers’ SSL certificates, which might prevent some people from choosing this library.