### PR TITLE
Add support for AWS Session Token Service (AWS STS) credentials.

### DIFF
--- a/Network/Wreq.hs
+++ b/Network/Wreq.hs
@@ -94,6 +94,7 @@ module Network.Wreq
     , oauth2Bearer
     , oauth2Token
     , awsAuth
+    , awsSessionTokenAuth
     -- ** Proxy settings
     , Proxy(Proxy)
     , Lens.proxy
@@ -525,7 +526,25 @@ oauth2Token = OAuth2Token
 --'getWith' opts \"https:\/\/dynamodb.us-west-2.amazonaws.com\"
 -- @
 awsAuth :: AWSAuthVersion -> S.ByteString -> S.ByteString -> Auth
-awsAuth = AWSAuth
+awsAuth version key secret = AWSAuth version key secret Nothing
+
+-- | AWS v4 request signature using a AWS STS Session Token.
+--
+-- Example (note the use of TLS):
+--
+-- @
+--let opts = 'defaults'
+--           '&' 'Lens.auth'
+--           '?~' 'awsAuth AWSv4' \"key\" \"secret\" \"stsSessionToken\"
+--'getWith' opts \"https:\/\/dynamodb.us-west-2.amazonaws.com\"
+-- @
+awsSessionTokenAuth :: AWSAuthVersion -- ^ Signature version (V4)
+                    -> S.ByteString   -- ^ AWS AccessKeyId
+                    -> S.ByteString   -- ^ AWS SecretAccessKey
+                    -> S.ByteString   -- ^ AWS STS SessionToken
+                    -> Auth
+awsSessionTokenAuth version key secret sessionToken =
+  AWSAuth version key secret (Just sessionToken)
 
 -- | Proxy configuration.
 --

--- a/Network/Wreq/Internal/Types.hs
+++ b/Network/Wreq/Internal/Types.hs
@@ -179,9 +179,9 @@ data Auth = BasicAuth S.ByteString S.ByteString
             -- to be used only by GitHub). This is treated by whoever
             -- accepts it as the equivalent of a username and
             -- password.
-          | AWSAuth AWSAuthVersion S.ByteString S.ByteString
+          | AWSAuth AWSAuthVersion S.ByteString S.ByteString (Maybe S.ByteString)
             -- ^ Amazon Web Services request signing
-            -- AWSAuthVersion key secret
+            -- AWSAuthVersion key secret (optional: session-token)
           | OAuth1 S.ByteString S.ByteString S.ByteString S.ByteString
             -- ^ OAuth1 request signing
             -- OAuth1 consumerToken consumerSecret token secret

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,16 @@
 -*- markdown -*-
 
+2017-12-23 0.5.1.1
+
+* Add awsSessionTokenAuth (in addition to the existing awsAuth) to
+  support AWS Session Token Service (AWS STS) credentials. These look
+  like regular AWS credentials but have an additional session token as
+  a 3rd element. This mechanism is needed to be able to (a) use EC2
+  instance profiles, (b) make calls form AWS Lambda, (c) is useful for
+  delegated role access (assumeRole within and across accounts), and (d)
+  enables MFA-protected access scenarios.
+  See tests/AWS/IAM.hs for a test and simple example.
+
 2017-01-09 0.5.1.0
 
 * Add Session-specific version of Network.Wreq.customPayloadMethodWith

--- a/tests/AWS.hs
+++ b/tests/AWS.hs
@@ -14,12 +14,9 @@ To configure and run these tests you need an AWS account. We assume
 that you are familiar with AWS concepts and the charging model.
 
 ** ENABLING AWS TESTS **
-For now, enable AWS tests by setting the WREQ_AWS_ACCESS_KEY_ID
-env variable per below.
-
-TODO| To enable AWS tests use the `-faws` flag as part of
-TODO|   $ cabal configure --enable-tests -faws ...
-TODO| To capture code coverage information, add the `-fdeveloper` flag.
+To enable AWS tests use the `-faws` flag as part of
+  $ cabal configure --enable-tests -faws ...
+To capture code coverage information, add the `-fdeveloper` flag.
 
 ** REQUIRED CLIENT CONFIGURATION **
 The tests require two environment variables:
@@ -76,20 +73,6 @@ import qualified AWS.SQS (tests)
 
 tests :: IO Test
 tests = do
-  -- TODO - use ... configure -faws ... in the future
-  --        but couldn't figure out (yet) how to get
-  --        a hold of the flag value in test code.
-  -- Workaround: for now, the presence of the
-  --   WREQ_AWS_ACCESS_KEY_ID
-  -- env variable enables the tests.
-  flag <- (getEnv "WREQ_AWS_ACCESS_KEY_ID" >> return True) `E.catch`
-          \(_::IOException) -> return False
-  tests0 flag
-
-tests0 :: Bool -> IO Test
-tests0 False =
-  return $ testGroup "aws" [] -- skip AWS tests
-tests0 True = do
   region <- env "us-west-2" "WREQ_AWS_REGION"
   key <- BS8.pack `fmap` getEnv "WREQ_AWS_ACCESS_KEY_ID"
   secret <- BS8.pack `fmap` getEnv "WREQ_AWS_SECRET_ACCESS_KEY"

--- a/tests/UnitTests.hs
+++ b/tests/UnitTests.hs
@@ -12,7 +12,7 @@ import Control.Concurrent.MVar (newEmptyMVar, putMVar, takeMVar)
 import Control.Exception (Exception, throwIO)
 import Control.Lens ((^.), (^?), (.~), (?~), (&), iso, ix, Traversal')
 import Control.Monad (unless, void)
-import Data.Aeson
+import Data.Aeson hiding (Options)
 import Data.Aeson.Lens (key, AsValue, _Object)
 import Data.ByteString (ByteString)
 import Data.Char (toUpper)

--- a/wreq.cabal
+++ b/wreq.cabal
@@ -1,5 +1,5 @@
 name:                wreq
-version:             0.5.1.0
+version:             0.5.1.1
 synopsis:            An easy-to-use HTTP client library.
 description:
   .


### PR DESCRIPTION
Please consider including this pull request. I very much appreciate the ongoing support for Wreq and am adding this change to be able to move a bunch of my Lambda code to GHC 8.2.2 and Wreq 5.*. Please see the new changelog.md entry for more details. 