### PR TITLE
Update the examples involving StatusCodeException and update examples referencing deprecated with* functions.

### DIFF
--- a/Network/Wreq/Session.hs
+++ b/Network/Wreq/Session.hs
@@ -18,7 +18,7 @@
 --
 -- * Transparent cookie management.  Any cookies set by the server
 --   persist from one request to the next.  (Bypass this overhead
---   using 'withAPISession'.)
+--   using 'newAPISession'.)
 --
 --
 -- This module is designed to be used alongside the "Network.Wreq"
@@ -28,19 +28,20 @@
 -- import "Network.Wreq"
 -- import qualified "Network.Wreq.Session" as Sess
 --
--- main = Sess.'withSession' $ \\sess ->
+-- main = do
+--   sess <- Sess.'newSession'
 --   Sess.'get' sess \"http:\/\/httpbin.org\/get\"
 -- @
 --
--- We create a 'Session' using 'withSession', then pass the session to
+-- We create a 'Session' using 'newSession', then pass the session to
 -- subsequent functions.  When talking to a REST-like service that does
--- not use cookies, it is more efficient to use 'withAPISession'.
+-- not use cookies, it is more efficient to use 'newAPISession'.
 --
 -- Note the use of qualified import statements in the examples above,
 -- so that we can refer unambiguously to the 'Session'-specific
 -- implementation of HTTP GET.
 --
--- One 'Network.HTTP.Client.Manager' (possibly set with 'withSessionControl') is used for all
+-- One 'Network.HTTP.Client.Manager' (possibly set with 'newSessionControl') is used for all
 -- session requests. The manager settings in the 'Options' parameter
 -- for the 'getWith', 'postWith' and similar functions is ignored.
 

--- a/www/tutorial.md
+++ b/www/tutorial.md
@@ -583,7 +583,8 @@ import Network.Wreq
 import qualified Network.Wreq.Session as S
 
 main :: IO ()
-main = S.withSession $ \sess -> do
+main = do
+  sess <- S.newSession
   -- First request: tell the server to set a cookie
   S.get sess "http://httpbin.org/cookies/set?name=hi"
 
@@ -599,8 +600,7 @@ The key differences from the basic API are as follows.
   module qualified, and we'll identify its functions by prefixing them
   with "`S.`".
 
-* To create a `Session`, we use `S.withSession`. It calls our code
-  with `sess`, the `Session` value we'll use.
+* To create a `Session`, we use `S.newSession`.
 
 * Instead of `get` and `post`, we call the `Session`-specific
   versions, [`S.get`](http://hackage.haskell.org/package/wreq/docs/Network-Wreq-Session.html#v:get) and [`S.post`](http://hackage.haskell.org/package/wreq/docs/Network-Wreq-Session.html#v:post), and pass `sess` to each of them.


### PR DESCRIPTION
Warning: I'm a very fresh Haskeller, so I don't know if this is idiomatic code, but I think it's correct and it works for me. The previous version seems to be written for an older version of `wreq`/`http-client`.