### PR TITLE
This patch makes `wreq` compilable down to GHC-7.4

### DIFF
--- a/Network/Wreq/Session.hs
+++ b/Network/Wreq/Session.hs
@@ -94,6 +94,7 @@ import qualified Data.ByteString.Lazy as L
 import qualified Network.HTTP.Client as HTTP
 import qualified Network.Wreq.Internal.Lens as Lens
 import qualified Network.Wreq.Lens as Lens
+import Data.Traversable as T
 
 -- | Create a 'Session', passing it to the given function.  The
 -- 'Session' will no longer be valid after that function returns.
@@ -170,7 +171,7 @@ newSessionControl mj settings = do
 --
 -- @since 0.5.2.0
 getSessionCookieJar :: Session -> IO (Maybe HTTP.CookieJar)
-getSessionCookieJar = traverse readIORef . seshCookies
+getSessionCookieJar = T.traverse readIORef . seshCookies
 
 -- | 'Session'-specific version of 'Network.Wreq.get'.
 get :: Session -> String -> IO (Response L.ByteString)
@@ -263,7 +264,7 @@ customHistoriedPayloadMethodWith method opts sesh url payload =
 
 runWithGeneric :: (resp -> Response b) -> Session -> (Req -> IO resp) -> Req -> IO resp
 runWithGeneric extract Session{..} act (Req _ req) = do
-  req' <- (\c -> req & Lens.cookieJar .~ c) <$> traverse readIORef seshCookies
+  req' <- (\c -> req & Lens.cookieJar .~ c) `fmap` T.traverse readIORef seshCookies
   resp <- act (Req (Right seshManager) req')
   forM_ seshCookies $ \ref ->
     writeIORef ref (HTTP.responseCookieJar (extract resp))

--- a/Network/Wreq/Types.hs
+++ b/Network/Wreq/Types.hs
@@ -71,7 +71,7 @@ instance Putable Part where
 instance Putable [Part] where
     putPayload p req =
         -- According to doc, formDataBody changes the request type to POST which is wrong; change it back
-        (\r -> r{method=method req}) <$> formDataBody p req
+        (\r -> r{method=method req}) `fmap` formDataBody p req
 
 instance Putable [(S.ByteString, S.ByteString)] where
     putPayload ps req =

--- a/wreq.cabal
+++ b/wreq.cabal
@@ -1,5 +1,5 @@
 name:                wreq
-version:             0.5.2.0
+version:             0.5.2.1
 synopsis:            An easy-to-use HTTP client library.
 description:
   .
@@ -36,7 +36,7 @@ maintainer:          bos@serpentine.com
 copyright:           2014 Bryan O'Sullivan
 category:            Web
 build-type:          Custom
-cabal-version:       >=1.24
+cabal-version:       >=1.10
 tested-with:         GHC==8.2.1, GHC==8.0.2, GHC==7.10.3, GHC==7.8.4, GHC==7.6.3, GHC==7.4.2
 extra-source-files:
   README.md


### PR DESCRIPTION
The Applicative-Monad and Foldable-Traversable breakages are easy part.

cabal-version: can be >=1.10 as one doesn't need bump it to >=1.24
for custom-setup to take an affect. I will correct cabal-doctest
example soon. Having cabal-version: >=1.24 causes configuration
problem with Cabal-1.22:

    setup: This package description follows version 1.24 of the Cabal
    specification. This tool only supports up to version 1.22.5.0.

---

I also made revisions:
- https://hackage.haskell.org/package/wreq-0.5.2.0/revisions/
- https://hackage.haskell.org/package/wreq-0.5.1.0/revisions/

to make matrix greener: https://matrix.hackage.haskell.org/package/wreq#GHC-7.10/wreq-0.5.2.0
(deps problem with ghc-7.8.4 is https://github.com/vincenthz/hs-memory/issues/44, hopefully it will be figured out soon).