### PR TITLE
Session module doc: avoid deprecated functions

### DIFF
--- a/Network/Wreq/Session.hs
+++ b/Network/Wreq/Session.hs
@@ -28,11 +28,11 @@
 -- import "Network.Wreq"
 -- import qualified "Network.Wreq.Session" as Sess
 --
--- main = Sess.'withSession' $ \\sess ->
+-- main = Sess.'newSession' >>= \\sess ->
 --   Sess.'get' sess \"http:\/\/httpbin.org\/get\"
 -- @
 --
--- We create a 'Session' using 'withSession', then pass the session to
+-- We create a 'Session' using 'newSession', then pass the session to
 -- subsequent functions.  When talking to a REST-like service that does
 -- not use cookies, it is more efficient to use 'withAPISession'.
 --
@@ -40,7 +40,7 @@
 -- so that we can refer unambiguously to the 'Session'-specific
 -- implementation of HTTP GET.
 --
--- One 'Network.HTTP.Client.Manager' (possibly set with 'withSessionControl') is used for all
+-- One 'Network.HTTP.Client.Manager' (possibly set with 'newSessionControl') is used for all
 -- session requests. The manager settings in the 'Options' parameter
 -- for the 'getWith', 'postWith' and similar functions is ignored.
 


### PR DESCRIPTION
This updates the module haddock for `Network.Wreq.Session` so that it no longer recommends using deprecated functions.