### PR TITLE
Allowing manual specification of region for AWSV4 authentication

### DIFF
--- a/Network/Wreq.hs
+++ b/Network/Wreq.hs
@@ -98,6 +98,7 @@ module Network.Wreq
     , oauth2Bearer
     , oauth2Token
     , awsAuth
+    , awsFullAuth
     , awsSessionTokenAuth
     -- ** Proxy settings
     , Proxy(Proxy)
@@ -599,6 +600,17 @@ awsSessionTokenAuth :: AWSAuthVersion -- ^ Signature version (V4)
                     -> Auth
 awsSessionTokenAuth version key secret sessionToken =
   AWSAuth version key secret (Just sessionToken)
+
+-- | AWS v4 request signature.
+--
+-- Example (note the use of TLS):
+--
+-- @
+--let opts = 'defaults' '&' 'Lens.auth' '?~' 'awsFullAuth' 'AWSv4' \"key\" \"secret\" (Just (\"service\", \"region\"))
+--'getWith' opts \"https:\/\/dynamodb.us-west-2.amazonaws.com\"
+-- @
+awsFullAuth :: AWSAuthVersion -> S.ByteString -> S.ByteString -> Maybe S.ByteString -> Maybe (S.ByteString, S.ByteString) -> Auth
+awsFullAuth = AWSFullAuth
 
 -- | Proxy configuration.
 --

--- a/Network/Wreq/Internal/Types.hs
+++ b/Network/Wreq/Internal/Types.hs
@@ -183,6 +183,9 @@ data Auth = BasicAuth S.ByteString S.ByteString
           | AWSAuth AWSAuthVersion S.ByteString S.ByteString (Maybe S.ByteString)
             -- ^ Amazon Web Services request signing
             -- AWSAuthVersion key secret (optional: session-token)
+          | AWSFullAuth AWSAuthVersion S.ByteString S.ByteString  (Maybe S.ByteString) (Maybe (S.ByteString, S.ByteString))
+            -- ^ Amazon Web Services request signing
+            -- AWSAuthVersion key secret Maybe (service, region)
           | OAuth1 S.ByteString S.ByteString S.ByteString S.ByteString
             -- ^ OAuth1 request signing
             -- OAuth1 consumerToken consumerSecret token secret


### PR DESCRIPTION
Adding a change to allow manual specification of the region for AWSv4 authentication, for cases where the region is not part of the url.